### PR TITLE
Result not in the paper

### DIFF
--- a/text_classification.md
+++ b/text_classification.md
@@ -13,7 +13,6 @@ pertaining to the 4 largest classes. The dataset contains 30,000 training exampl
 | Model           | Error  |  Paper / Source |
 | ------------- | :-----:| --- |
 | ULMFiT (Howard and Ruder, 2018) | 5.01 | [Universal Language Model Fine-tuning for Text Classification](https://arxiv.org/abs/1801.06146) |
-| CNN (Johnson and Zhang, 2016) | 6.57 | [Supervised and Semi-Supervised Text Categorization using LSTM for Region Embeddings](https://arxiv.org/abs/1602.02373) |
 | DPCNN (Johnson and Zhang, 2017) | 6.87 | [Deep Pyramid Convolutional Neural Networks for Text Categorization](http://aclweb.org/anthology/P17-1052) |
 | VDCN (Alexis et al., 2016) | 8.67 | [Very Deep Convolutional Networks for Text Classification](https://arxiv.org/abs/1606.01781) |
 | Char-level CNN (Zhang et al., 2015) | 9.51 | [Character-level Convolutional Networks for Text Classification](https://papers.nips.cc/paper/5782-character-level-convolutional-networks-for-text-classification.pdf) |

--- a/text_classification.md
+++ b/text_classification.md
@@ -13,9 +13,12 @@ pertaining to the 4 largest classes. The dataset contains 30,000 training exampl
 | Model           | Error  |  Paper / Source |
 | ------------- | :-----:| --- |
 | ULMFiT (Howard and Ruder, 2018) | 5.01 | [Universal Language Model Fine-tuning for Text Classification](https://arxiv.org/abs/1801.06146) |
+| CNN (Johnson and Zhang, 2016) * | 6.57 | [Supervised and Semi-Supervised Text Categorization using LSTM for Region Embeddings](https://arxiv.org/abs/1602.02373) |
 | DPCNN (Johnson and Zhang, 2017) | 6.87 | [Deep Pyramid Convolutional Neural Networks for Text Categorization](http://aclweb.org/anthology/P17-1052) |
 | VDCN (Alexis et al., 2016) | 8.67 | [Very Deep Convolutional Networks for Text Classification](https://arxiv.org/abs/1606.01781) |
 | Char-level CNN (Zhang et al., 2015) | 9.51 | [Character-level Convolutional Networks for Text Classification](https://papers.nips.cc/paper/5782-character-level-convolutional-networks-for-text-classification.pdf) |
+
+\* Results reported in Johnson and Zhang, 2017
 
 ### DBpedia
 


### PR DESCRIPTION
The result:

| CNN (Johnson and Zhang, 2016) | 6.57 | [Supervised and Semi-Supervised Text Categorization using LSTM for Region Embeddings](https://arxiv.org/abs/1602.02373) |

does not appear in the mentioned paper.