### PR TITLE
Data in YAML for structure and plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site/
+Gemfile*

--- a/_data/ccg_supertagging.yaml
+++ b/_data/ccg_supertagging.yaml
@@ -1,0 +1,23 @@
+- year:     2016
+  authors:  Lewis et al.
+  accuracy: 94.7
+  paper:    LSTM CCG Parsing
+  url:      https://aclweb.org/anthology/N/N16/N16-1026.pdf
+
+- year:     2016
+  authors:  Vaswani et al.
+  accuracy: 94.24
+  paper:    Supertagging with LSTMs
+  url:      https://aclweb.org/anthology/N/N16/N16-1027.pdf
+
+- year:     2016
+  authors:  Søgaard and Goldberg
+  accuracy: 93.26
+  paper:    Deep multi-task learning with low level tasks supervised at lower layers
+  url:      http://anthology.aclweb.org/P16-2038
+
+- year:     2015
+  authors:  Xu et al.
+  accuracy: 93.00
+  paper:    CCG Supertagging with a Recurrent Neural Network
+  url:      http://www.aclweb.org/anthology/P15-2041

--- a/_data/ccg_supertagging.yaml
+++ b/_data/ccg_supertagging.yaml
@@ -10,7 +10,8 @@
   paper:    Supertagging with LSTMs
   url:      https://aclweb.org/anthology/N/N16/N16-1027.pdf
 
-- year:     2016
+- model:    Low supervision
+  year:     2016
   authors:  Søgaard and Goldberg
   accuracy: 93.26
   paper:    Deep multi-task learning with low level tasks supervised at lower layers

--- a/_data/chunking.yaml
+++ b/_data/chunking.yaml
@@ -1,0 +1,12 @@
+- model:    Low supervision
+  authors:  Søgaard and Goldberg
+  year:     2016
+  F1 score: 95.57
+  paper:    Deep multi-task learning with low level tasks supervised at lower layers
+  url:      http://anthology.aclweb.org/P16-2038
+
+- authors:  Suzuki and Isozaki
+  year:     2008
+  F1 score: 95.15
+  paper:    Semi-Supervised Sequential Labeling and Segmentation using Giga-word Scale Unlabeled Data
+  url:      https://aclanthology.info/pdf/P/P08/P08-1076.pdf

--- a/_data/constituency_parsing.yaml
+++ b/_data/constituency_parsing.yaml
@@ -1,0 +1,63 @@
+-
+  model:   Self-attentive encoder + ELMo
+  authors: Kitaev and Klein
+  year:    2018
+  F1 score: 95.13
+  paper:   Constituency Parsing with a Self-Attentive Encoder
+  url:     https://arxiv.org/abs/1805.01052
+-
+  model:   Model combination
+  authors: Fried et al.
+  year:    2017
+  F1 score: 94.66
+  paper:   Improving Neural Parsing by Disentangling Model Combination and Reranking Effects
+  url:     https://arxiv.org/abs/1707.03058
+-
+  model:   In-order
+  authors: Liu and Zhang
+  year:    2017
+  F1 score: 94.2
+  paper:   In-Order Transition-based Constituent Parsing
+  url:     http://aclweb.org/anthology/Q17-1029
+-
+  model:   Semi-supervised LSTM-LM
+  authors: Choe and Charniak
+  year:    2016
+  F1 score: 93.8
+  paper:   Parsing as Language Modeling
+  url:     http://www.aclweb.org/anthology/D16-1257
+-
+  model:   Stack-only RNNG
+  authors: Kuncoro et al.
+  year:    2017
+  F1 score: 93.6
+  paper:   What Do Recurrent Neural Network Grammars Learn About Syntax?
+  url:     https://arxiv.org/abs/1611.05774
+-
+  model:   RNN Grammar
+  authors: Dyer et al.
+  year:    2016
+  F1 score: 93.3
+  paper:   Recurrent Neural Network Grammars
+  url:     https://www.aclweb.org/anthology/N16-1024
+-
+  model:   Transformer
+  authors: Vaswani et al.
+  year:    2017
+  F1 score: 92.7
+  paper:   Attention Is All You Need
+  url:     https://arxiv.org/abs/1706.03762
+-
+  model:   Semi-supervised LSTM
+  authors: Vinyals et al.
+  year:    2015
+  F1 score: 92.1
+  paper:   Grammar as a Foreign Language
+  url:     https://papers.nips.cc/paper/5635-grammar-as-a-foreign-language.pdf
+-
+  model:   Self-trained parser
+  authors: McClosky et al.
+  year:    2006
+  F1 score: 92.1
+  paper:   Effective Self-Training for Parsing
+  url:     https://pdfs.semanticscholar.org/6f0f/64f0dab74295e5eb139c160ed79ff262558a.pdf

--- a/_includes/chart.html
+++ b/_includes/chart.html
@@ -13,8 +13,9 @@
 
 <div class="chart">
 {% for result in include.results %}
-  <div style="width: {{ result.accuracy | times: 5.0 }}px;">
-    {{ result.accuracy }}
+{% assign score = result[include.score] %}
+  <div style="width: {{ score | times: 5.0 }}px;">
+    {{ score }}
   </div>
 {% endfor %}
 </div>

--- a/_includes/chart.html
+++ b/_includes/chart.html
@@ -1,0 +1,20 @@
+<style>
+
+.chart div {
+  font: 18px sans-serif;
+  background-color: steelblue;
+  text-align: right;
+  padding: 6px;
+  margin: 2px;
+  color: white;
+}
+
+</style>
+
+<div class="chart">
+{% for result in include.results %}
+  <div style="width: {{ result.accuracy | times: 5.0 }}px;">
+    {{ result.accuracy }}
+  </div>
+{% endfor %}
+</div>

--- a/_includes/chart.html
+++ b/_includes/chart.html
@@ -3,10 +3,17 @@
 .chart div {
   font: 18px sans-serif;
   background-color: steelblue;
-  text-align: right;
   padding: 6px;
   margin: 2px;
   color: white;
+  height: 40px;
+}
+
+.alignleft {
+	float: left;
+}
+.alignright {
+	float: right;
 }
 
 </style>
@@ -15,7 +22,8 @@
 {% for result in include.results %}
 {% assign score = result[include.score] %}
   <div style="width: {{ score | times: 5.0 }}px;">
-    {{ score }}
+    <p class="alignleft">{{ result.authors }} ({{ result.year }})</p>
+    <p class="alignright">{{ score }}</p>
   </div>
 {% endfor %}
 </div>

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -9,7 +9,7 @@
   <tbody>
   {% for result in include.results %}
     <tr>
-      <td>{{ result.authors }} ({{ result.year }})</td>
+      <td>{% if result.model %} {{ result.model }} by {% endif %} {{ result.authors }} ({{ result.year }})</td>
       <td style="text-align: center">{{ result.accuracy }}</td>
       <td><a href="{{ result.url }}">{{ result.paper }}</a></td>
     </tr>

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -1,0 +1,18 @@
+<table>
+  <thead>
+    <tr>
+      <th>Model</th>
+      <th style="text-align: center">Accuracy</th>
+      <th>Paper / Source</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for result in include.results %}
+    <tr>
+      <td>{{ result.authors }} ({{ result.year }})</td>
+      <td style="text-align: center">{{ result.accuracy }}</td>
+      <td><a href="{{ result.url }}">{{ result.paper }}</a></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -2,15 +2,16 @@
   <thead>
     <tr>
       <th>Model</th>
-      <th style="text-align: center">Accuracy</th>
+      <th style="text-align: center">{{ include.score | capitalize }}</th>
       <th>Paper / Source</th>
     </tr>
   </thead>
   <tbody>
   {% for result in include.results %}
+    {% assign score = result[include.score] %}
     <tr>
       <td>{% if result.model %} {{ result.model }} by {% endif %} {{ result.authors }} ({{ result.year }})</td>
-      <td style="text-align: center">{{ result.accuracy }}</td>
+      <td style="text-align: center">{{ score }}</td>
       <td><a href="{{ result.url }}">{{ result.paper }}</a></td>
     </tr>
   {% endfor %}

--- a/ccg_supertagging.md
+++ b/ccg_supertagging.md
@@ -12,16 +12,11 @@ Example:
 
 ### CCGBank
 
-The CCGBank is a corpus of CCG derivations and dependency structures extracted from the Penn Treebank by 
-[Hockenmaier and Steedman (2007)](http://www.aclweb.org/anthology/J07-3004). Sections 2-21 are used for training, 
+The CCGBank is a corpus of CCG derivations and dependency structures extracted from the Penn Treebank by
+[Hockenmaier and Steedman (2007)](http://www.aclweb.org/anthology/J07-3004). Sections 2-21 are used for training,
 section 00 for development, and section 23 as in-domain test set.
 Performance is only calculated on the 425 most frequent labels. Models are evaluated based on accuracy.
 
-| Model           | Accuracy |  Paper / Source |
-| ------------- | :-----:| --- |
-| Lewis et al. (2016) | 94.7 | [LSTM CCG Parsing](https://aclweb.org/anthology/N/N16/N16-1026.pdf) |
-| Vaswani et al. (2016) | 94.24 | [Supertagging with LSTMs](https://aclweb.org/anthology/N/N16/N16-1027.pdf) |
-| Low supervision (Søgaard and Goldberg, 2016) | 93.26 | [Deep multi-task learning with low level tasks supervised at lower layers](http://anthology.aclweb.org/P16-2038) |
-| Xu et al. (2015) | 93.00 | [CCG Supertagging with a Recurrent Neural Network](http://www.aclweb.org/anthology/P15-2041) |
+{% include table.html results=site.data.ccg_supertagging %}
 
 [Go back to the README](README.md)

--- a/ccg_supertagging.md
+++ b/ccg_supertagging.md
@@ -19,4 +19,6 @@ Performance is only calculated on the 425 most frequent labels. Models are evalu
 
 {% include table.html results=site.data.ccg_supertagging %}
 
+{% include chart.html results=site.data.ccg_supertagging %}
+
 [Go back to the README](README.md)

--- a/ccg_supertagging.md
+++ b/ccg_supertagging.md
@@ -17,8 +17,8 @@ The CCGBank is a corpus of CCG derivations and dependency structures extracted f
 section 00 for development, and section 23 as in-domain test set.
 Performance is only calculated on the 425 most frequent labels. Models are evaluated based on accuracy.
 
-{% include table.html results=site.data.ccg_supertagging %}
+{% include table.html results=site.data.ccg_supertagging score='accuracy' %}
 
-{% include chart.html results=site.data.ccg_supertagging %}
+{% include chart.html results=site.data.ccg_supertagging score='accuracy' %}
 
 [Go back to the README](README.md)

--- a/chunking.md
+++ b/chunking.md
@@ -14,9 +14,8 @@ The [Penn Treebank](https://catalog.ldc.upenn.edu/LDC99T42) is typically used fo
 Sections 15-18 are used for training, section 19 for development, and and section 20
 for testing. Models are evaluated based on F1.
 
-| Model           | F1 score  |  Paper / Source |
-| ------------- | :-----:| --- |
-| Low supervision (Søgaard and Goldberg, 2016) | 95.57 | [Deep multi-task learning with low level tasks supervised at lower layers](http://anthology.aclweb.org/P16-2038) |
-| Suzuki and Isozaki (2008) | 95.15 | [Semi-Supervised Sequential Labeling and Segmentation using Giga-word Scale Unlabeled Data](https://aclanthology.info/pdf/P/P08/P08-1076.pdf) | 
+{% include table.html results=site.data.chunking score='F1 score' %}
+
+{% include chart.html results=site.data.chunking score='F1 score' %}
 
 [Go back to the README](README.md)

--- a/constituency_parsing.md
+++ b/constituency_parsing.md
@@ -1,6 +1,6 @@
 # Constituency parsing
 
-Consituency parsing aims to extract a constituency-based parse tree from a sentence that 
+Consituency parsing aims to extract a constituency-based parse tree from a sentence that
 represents its syntactic structure according to a [phrase structure grammar](https://en.wikipedia.org/wiki/Phrase_structure_grammar).
 
 Example:
@@ -21,24 +21,16 @@ Example:
 convert the parse tree into a sequence following a depth-first traversal in order to
 be able to apply sequence-to-sequence models to it. The linearized version of the
 above parse tree looks as follows: (S (N) (VP V N)).
- 
+
 ### Penn Treebank
 
-The Wall Street Journal section of the [Penn Treebank](https://catalog.ldc.upenn.edu/LDC99T42) is used for 
+The Wall Street Journal section of the [Penn Treebank](https://catalog.ldc.upenn.edu/LDC99T42) is used for
 evaluating constituency parsers. Section 22 is used for development and Section 23 is used for evaluation.
 Models are evaluated based on F1. Most of the below models incorporate external data or features.
 For a comparison of single models trained only on WSJ, refer to [Kitaev and Klein (2018)](https://arxiv.org/abs/1805.01052).
 
-| Model           | F1 score  |  Paper / Source |
-| ------------- | :-----:| --- |
-| Self-attentive encoder + ELMo (Kitaev and Klein, 2018) | 95.13 | [Constituency Parsing with a Self-Attentive Encoder](https://arxiv.org/abs/1805.01052) |
-| Model combination (Fried et al., 2017) | 94.66 | [Improving Neural Parsing by Disentangling Model Combination and Reranking Effects](https://arxiv.org/abs/1707.03058) |
-| In-order (Liu and Zhang, 2017) | 94.2 | [In-Order Transition-based Constituent Parsing](http://aclweb.org/anthology/Q17-1029) |
-| Semi-supervised LSTM-LM (Choe and Charniak, 2016) | 93.8 | [Parsing as Language Modeling](http://www.aclweb.org/anthology/D16-1257) | 
-| Stack-only RNNG (Kuncoro et al., 2017) | 93.6 | [What Do Recurrent Neural Network Grammars Learn About Syntax?](https://arxiv.org/abs/1611.05774) |
-| RNN Grammar (Dyer et al., 2016) | ﻿93.3 | [Recurrent Neural Network Grammars](https://www.aclweb.org/anthology/N16-1024) |
-| Transformer (Vaswani et al., 2017) | 92.7 | [Attention Is All You Need](https://arxiv.org/abs/1706.03762) |
-| Semi-supervised LSTM (Vinyals et al., 2015) | 92.1  | [Grammar as a Foreign Language](https://papers.nips.cc/paper/5635-grammar-as-a-foreign-language.pdf) |
-| Self-trained parser (McClosky et al., 2006) | 92.1 | [Effective Self-Training for Parsing](https://pdfs.semanticscholar.org/6f0f/64f0dab74295e5eb139c160ed79ff262558a.pdf) |
+{% include table.html results=site.data.constituency_parsing score='F1 score' %}
+
+{% include chart.html results=site.data.constituency_parsing score='F1 score' %}
 
 [Go back to the README](README.md)


### PR DESCRIPTION
Related to #43.

Right now did some demo for CCG. I didn't work on the plot form, just wanted to show it is possible and easy. Also - I think that data form can be standarized - so it would be simpler to add more complicated things (e.g. further comments, links to multiple implementations, etc).

See files in:

* `_data` - data in YAML format
* `_includes` - for ways of converting data into its presentations (tables, charts, etc)
* `ccg_supertagging.md` to see how to include these

IMHO YAML is cleaner for writing and reading than markdown tables, so it is an advantage on its own. From my experience contributors (ones who use GitHub) have no slightest problem in using YAML (vide https://p.migdal.pl/interactive-machine-learning-list/).

Right now I generate data through Liquid template.

* [D3.js Visualizations Using YAML and Jekyll](http://d3.js.yaml.jekyll.apievangelist.com/) - generating JSON via Liquid (but it is kind of ugly)
* loading YAML with [js-yaml](https://github.com/nodeca/js-yaml) and then using D3.js (or Vue.js, or other library)