### PR TITLE
TREC-6 SOTA

### DIFF
--- a/text_classification.md
+++ b/text_classification.md
@@ -45,6 +45,7 @@ TREC-6:
 
 | Model           | Error  |  Paper / Source | Code |
 | ------------- | :-----:| --- | :-----: |
+| USE (Cer et al., 2018) | 1.93 | [Universal Sentence Encoder](https://arxiv.org/pdf/1803.11175.pdf) | [Official](https://tfhub.dev/google/universal-sentence-encoder/1) |
 | ULMFiT (Howard and Ruder, 2018) | 3.6 | [Universal Language Model Fine-tuning for Text Classification](https://arxiv.org/abs/1801.06146) | [Official](http://nlp.fast.ai/ulmfit ) |
 | LSTM-CNN (Zhou et al., 2016) | 3.9 | [Text Classification Improved by Integrating Bidirectional LSTM with Two-dimensional Max Pooling](http://www.aclweb.org/anthology/C16-1329) |
 | TBCNN (Mou et al., 2015) | 4 | [Discriminative Neural Sentence Modeling by Tree-Based Convolution](http://aclweb.org/anthology/D15-1279) |


### PR DESCRIPTION
Better SOTA for TREC-6 is reported by "Universal Sentence Encoder" paper.