### PR TITLE
WIP: Adding Tools, Research for non English languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ### Table of contents
 
+#### English
 - [ASR](asr.md)
 - [CCG supertagging](ccg_supertagging.md)
 - [Chunking](chunking.md)
@@ -33,6 +34,16 @@
 - [Temporal Processing](temporal_processing.md)
 - [Text classification](text_classification.md)
 - [Word Sense Disambiguation](word_sense_disambiguation.md)
+
+#### Korean
+- [Chunking](korean.md)
+- [Part-of-speech tagging](korean.md)
+
+#### Arabic
+- [Chunking](arabic.md)
+
+
+#### 
 
 This document aims to track the progress in Natural Language Processing (NLP) and give an overview
 of the state-of-the-art (SOTA) across the most common NLP tasks and their corresponding datasets.

--- a/korean.md
+++ b/korean.md
@@ -1,0 +1,13 @@
+# Korean
+
+## Chunking
+
+| Model/Library | Paper / Source | Code |
+| ------------- | :---: | --- |
+| KoNLPy:Korean natural language processing in Python | [KoNLPy](http://dmlab.snu.ac.kr/~lucypark/docs/2014-10-10-hclt.pdf) | [Official](https://github.com/konlpy/konlpy) |
+
+## Part of Speech Tagging
+
+| Model/Library | Paper / Source | Code |
+| ------------- | :---: | --- |
+| KoNLPy:Korean natural language processing in Python | [KoNLPy](http://dmlab.snu.ac.kr/~lucypark/docs/2014-10-10-hclt.pdf) | [Official](https://github.com/konlpy/konlpy) |


### PR DESCRIPTION
Hello, 

@sebastianruder this is just to confirm that I did understand our intended format correctly. I have added the page for Korean as a sample. 

Note: The Korean file now has the same lib/paper repeated twice for chunking and PoS-tagging because this lib does both. This is very common for most languages. 

*I am fine with this duplication for now*, later - we can merge out some tasks within the same language, as needed.

Is this a good starting point for us? 

PS: Do not merge this yet please