### PR TITLE
Point to Salesforce's leaderboard for WikiSQL

### DIFF
--- a/english/semantic_parsing.md
+++ b/english/semantic_parsing.md
@@ -169,11 +169,7 @@ Example:
 | ------------- |  --- |
 | How many engine types did Val Musetti use? | `SELECT COUNT Engine WHERE Driver = Val Musetti` | 
 
-| Model           | Acc ex |  Paper / Source |
-| -------------| :-----:| --- |
-| TypeSQL+TC (Yu et al., 2018) | 82.6 | [TypeSQL: Knowledge-based Type-Aware Neural Text-to-SQL Generation](https://arxiv.org/abs/1804.09769) |
-| SQLNet (Xu et al., 2017) | 68.0 | [Sqlnet: Generating structured queries from natural language without reinforcement learning](https://arxiv.org/abs/1711.04436) |
-| Seq2SQL (Zhong et al., 2017) | 59.4 | [Seq2sql: Generating structured queries from natural language using reinforcement learning](https://arxiv.org/abs/1709.00103) |
+The WikiSQL dataset and leaderboard can be accessed [here](https://github.com/salesforce/WikiSQL).
 
 ### Smaller Datasets
 


### PR DESCRIPTION
The leaderboard in the WikiSQL repo shows a bunch of newer implementations beating the ones shown here by a significant margin. Better to just link to the maintained WikiSQL leaderboard, like this page already does for the Spider dataset.

Alternatively, could update this table with those newer entries in the WikiSQL leaderboard. Note the current misalignment on TypeSQL: the WikiSQL leaderboard only lists the score for TypeSQL _without_ table content awareness (don't know why), while the leaderboard here only lists the score for TypeSQL _with_ table content awareness, hence the considerably higher score. Still, both are pretty far short of the current record holders in the WikiSQL leaderboard.