### PR TITLE
PoS tagging: correct and add new results

### DIFF
--- a/english/part-of-speech_tagging.md
+++ b/english/part-of-speech_tagging.md
@@ -49,6 +49,7 @@ Models are typically evaluated based on the average test accuracy across 21 high
 
 | Model           | Avg accuracy  |  Paper / Source |
 | ------------- | :-----:| --- |
+| Multilingual BERT and BPEmb (Heinzerling and Strube, 2019) | 96.77 | [Sequence Tagging with Contextual and Non-Contextual Subword Representations: A Multilingual Evaluation](https://arxiv.org/abs/1906.01569) |
 | Adversarial Bi-LSTM (Yasunaga et al., 2018) | 96.65 | [Robust Multilingual Part-of-Speech Tagging via Adversarial Training](https://arxiv.org/abs/1711.04903) | 
 | MultiBPEmb (Heinzerling and Strube, 2019) | 96.62 | [Sequence Tagging with Contextual and Non-Contextual Subword Representations: A Multilingual Evaluation](https://arxiv.org/abs/1906.01569) |
 | Bi-LSTM (Plank et al., 2016) | 96.40 | [Multilingual Part-of-Speech Tagging with Bidirectional Long Short-Term Memory Models and Auxiliary Loss](https://arxiv.org/abs/1604.05529) |

--- a/english/part-of-speech_tagging.md
+++ b/english/part-of-speech_tagging.md
@@ -45,12 +45,13 @@ The [Ritter (2011)](https://aclanthology.coli.uni-saarland.de/papers/D11-1141/d1
 
 [Universal Dependencies (UD)](http://universaldependencies.org/) is a framework for 
 cross-linguistic grammatical annotation, which contains more than 100 treebanks in over 60 languages.
-Models are typically evaluated based on the average test accuracy across 28 languages.
+Models are typically evaluated based on the average test accuracy across 21 high-resource languages (♦ evaluated on 17 languages).
 
 | Model           | Avg accuracy  |  Paper / Source |
 | ------------- | :-----:| --- |
-| Adversarial Bi-LSTM (Yasunaga et al., 2018) | 96.73 | [Robust Multilingual Part-of-Speech Tagging via Adversarial Training](https://arxiv.org/abs/1711.04903) | 
-| Bi-LSTM (Plank et al., 2016) | 96.40 | [Multilingual Part-of-Speech Tagging with Bidirectional Long Short-Term Memory Models and Auxiliary Loss](https://arxiv.org/abs/1604.05529) | 
-| Joint Bi-LSTM (Nguyen et al., 2017) | 95.55 | [A Novel Neural Network Model for Joint POS Tagging and Graph-based Dependency Parsing](https://arxiv.org/abs/1705.05952) |
+| Adversarial Bi-LSTM (Yasunaga et al., 2018) | 96.65 | [Robust Multilingual Part-of-Speech Tagging via Adversarial Training](https://arxiv.org/abs/1711.04903) | 
+| MultiBPEmb (Heinzerling and Strube, 2019) | 96.62 | [Sequence Tagging with Contextual and Non-Contextual Subword Representations: A Multilingual Evaluation](https://arxiv.org/abs/1906.01569) |
+| Bi-LSTM (Plank et al., 2016) | 96.40 | [Multilingual Part-of-Speech Tagging with Bidirectional Long Short-Term Memory Models and Auxiliary Loss](https://arxiv.org/abs/1604.05529) |
+| Joint Bi-LSTM (Nguyen et al., 2017)♦ | 95.55 | [A Novel Neural Network Model for Joint POS Tagging and Graph-based Dependency Parsing](https://arxiv.org/abs/1705.05952) |
 
 [Go back to the README](../README.md)


### PR DESCRIPTION
Hi,

this PR corrects and adds new results for PoS tagging on Universal Dependencies. The result from the Yasunaga et al. paper was too high and even not consistent with their [reported result](https://arxiv.org/pdf/1711.04903.pdf) (see table 2).

Additionally, the result from Nguyen et al., 2017 is not directly comparable to the other papers, because some languages are missing. So only 17 languages can directly be compared.

Furthermore, this PR adds some new results from an upcoming ACL paper by @bheinzerling and Strube: [Sequence Tagging with Contextual and Non-Contextual Subword Representations: A Multilingual Evaluation](https://arxiv.org/abs/1906.01569).

Here's a table that allows a direct comparison of all 21 languages across all papers:

Language | Joint Bi-LSTM | Bi-LSTM | Adversarial Bi-LSTM | MultiBPEmb | Multilingual BERT + BPEmb
-- | -- | -- | -- | -- | --
bg | 97.4 | 97.97 | 98.53 | 98.7 | 98.7
cs |   | 98.24 | 98.81 | 98.9 | 99
da | 95.8 | 96.35 | 96.74 | 97 | 97.2
de | 92.7 | 93.38 | 94.35 | 94 | 94.4
en | 94.7 | 95.16 | 95.82 | 95.6 | 96.1
es | 95.9 | 95.74 | 96.44 | 96.5 | 96.8
eu | 93.7 | 95.51 | 94.71 | 95.6 | 96
fa | 96.8 | 97.49 | 97.51 | 97.1 | 97.3
fi | 94.6 | 95.85 | 95.4 | 94.6 | 94.3
fr | 96 | 96.11 | 96.63 | 96.2 | 96.5
he |   | 96.96 | 97.43 | 96.6 | 97.3
hi | 96.4 | 97.1 | 97.21 | 97 | 97.4
hr |   | 96.82 | 96.32 | 96.8 | 96.8
id | 93.1 | 93.41 | 94.03 | 93.4 | 93.5
it | 97.5 | 97.95 | 98.08 | 98.1 | 98
nl | 91.4 | 93.3 | 93.09 | 93.8 | 93.3
no | 97.4 | 98.03 | 98.08 | 98.1 | 98.5
pl | 96.3 | 97.62 | 97.57 | 97.5 | 97.6
pt | 97.5 | 97.9 | 98.07 | 98.2 | 98.1
sl | 97.1 | 96.84 | 98.11 | 98 | 97.9
sv |   | 96.69 | 96.7 | 97.3 | 97.4
Average | 95.55 | 96.4 | 96.65 | 96.62 | 96.77

