### PR TITLE
Add part-of-speech tagging result

### DIFF
--- a/english/part-of-speech_tagging.md
+++ b/english/part-of-speech_tagging.md
@@ -22,6 +22,7 @@ different POS tags. Sections 0-18 are used for training, sections 19-21 for deve
 | Flair embeddings (Akbik et al., 2018) | 97.85 | [Contextual String Embeddings for Sequence Labeling](http://aclweb.org/anthology/C18-1139) | [Flair framework](https://github.com/zalandoresearch/flair) |
 | Char Bi-LSTM (Ling et al., 2015) | 97.78 | [Finding Function in Form: Compositional Character Models for Open Vocabulary Word Representation](https://www.aclweb.org/anthology/D/D15/D15-1176.pdf) | |
 | Adversarial Bi-LSTM (Yasunaga et al., 2018) | 97.59 | [Robust Multilingual Part-of-Speech Tagging via Adversarial Training](https://arxiv.org/abs/1711.04903) | |
+| BiLSTM-CRF + IntNet (Xin et al., 2018) | 97.58 | [Learning Better Internal Structure of Words for Sequence Labeling](https://www.aclweb.org/anthology/D18-1279) | |
 | Yang et al. (2017) | 97.55 | [Transfer Learning for Sequence Tagging with Hierarchical Recurrent Networks](https://arxiv.org/abs/1703.06345) | |
 | Ma and Hovy (2016) | 97.55 | [End-to-end Sequence Labeling via Bi-directional LSTM-CNNs-CRF](https://arxiv.org/abs/1603.01354) | |
 | LM-LSTM-CRF (Liu et al., 2018)| 97.53 | [Empowering Character-aware Sequence Labeling with Task-Aware Neural Language Model](https://arxiv.org/pdf/1709.04109.pdf) | |


### PR DESCRIPTION
Add part-of-speech tagging result with EMNLP 2018 long paper (Learning Better Internal Structure of Words for Sequence Labeling), this paper proposed IntNet, which mainly focus on learning better character-to-word representations, IntNet significantly outperformed other character embedding models, and also combined with BiLSTM-CRF achieved state-of-the-art part-of-speech tagging result without using any lexical features, transfer learning, language modeling or pre-training.