### PR TITLE
Update CNN/Daily Mail non-anonymized version

### DIFF
--- a/english/summarization.md
+++ b/english/summarization.md
@@ -48,6 +48,8 @@ The following models have been evaluated on the non-anonymized version of the da
 | Model           | ROUGE-1 | ROUGE-2 | ROUGE-L | METEOR | Paper / Source | Code |
 | --------------- | :-----: | :-----: | :-----: | :----: | -------------- | ---- |
 | BERTSUM (Liu, 2019) | 43.25 | 20.24 | 39.63 | - | [Fine-tune BERT for Extractive Summarization](https://arxiv.org/abs/1903.10318) |[Official](https://github.com/nlpyang/BertSum) |
+| HIBERT (Zhang et al., 2019) | 42.37 | 19.95 | 38.83 | - | [HIBERT: Document Level Pre-training of Hierarchical Bidirectional Transformers for Document Summarization](https://arxiv.org/abs/1905.06566) | |
+| Two-Stage + RL (Zhang et al., 2019) | 41.71 | 19.49 | 38.79 | - | [Pretraining-Based Natural Language Generation for Text Summarization](https://arxiv.org/abs/1902.09243) | |
 | DCA (Celikyilmaz et al., 2018) | 41.69 | 19.47 | 37.92 | - | [Deep Communicating Agents for Abstractive Summarization](http://aclweb.org/anthology/N18-1150) | |
 | EditNet (Moroshko et al., 2018) | 41.42 | 19.03 | 38.36 | - | [An Editorial Network for Enhanced Document Summarization](https://arxiv.org/abs/1902.10360) | |
 | NeuSUM (Zhou et al., 2018) | 41.59 | 19.01 | 37.98 | - | [Neural Document Summarization by Jointly Learning to Score and Select Sentences](http://aclweb.org/anthology/P18-1061) | [Official](https://github.com/magic282/NeuSum) |


### PR DESCRIPTION
add HIBERT (Zhang et al., 2019) and Two-Stage BERT (Zhang et al., 2019)