### PR TITLE
Fix Capturing discriminative attributes example table

### DIFF
--- a/english/relationship_extraction.md
+++ b/english/relationship_extraction.md
@@ -11,6 +11,7 @@ semantic categories (e.g. married to, employed by, lives in).
 e.g. red(attribute) can be used to discriminate apple (concept1) from banana (concept2) -> label 1
 
 More examples:
+
 | Attribute | concept1 | concept2 | label |
 | --------- | -------- | -------- | ----- |
 | bookcase | fridge | wood | 1 |


### PR DESCRIPTION
Add an extra line between "More examples:" and the markdown table to resolve markdown UI bug.

Preview of the before and after the change:
<img width="863" alt="screencap" src="https://user-images.githubusercontent.com/13449059/64924730-27cce700-d81a-11e9-8f85-ef02d9338081.png">

and thank you for maintaining this repository 👍 