### PR TITLE
Add ACL 2019 Nested NER results for CoNLL 2003

### DIFF
--- a/english/named_entity_recognition.md
+++ b/english/named_entity_recognition.md
@@ -18,6 +18,7 @@ corpus tagged with four different entity types (PER, LOC, ORG, MISC). Models are
 | Model           | F1  |  Paper / Source | Code |
 | ------------- | :-----:| --- | --- |
 | CNN Large + fine-tune (Baevski et al., 2019) | 93.5 | [Cloze-driven Pretraining of Self-attention Networks](https://arxiv.org/pdf/1903.07785.pdf) | |
+| LSTM-CRF+ELMo+BERT+Flair | 93.38 | [Neural Architectures for Nested NER through Linearization](https://www.aclweb.org/anthology/P19-1527/) | [Official](https://github.com/ufal/acl2019_nested_ner) |
 | Flair embeddings (Akbik et al., 2018)♦ | 93.09 | [Contextual String Embeddings for Sequence Labeling](https://drive.google.com/file/d/17yVpFA7MmXaQFTe-HDpZuqw9fJlmzg56/view) | [Flair framework](https://github.com/zalandoresearch/flair)
 | BERT Large (Devlin et al., 2018) | 92.8 | [BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding](https://arxiv.org/abs/1810.04805) | |
 | CVT + Multi-Task (Clark et al., 2018) | 92.61 | [Semi-Supervised Sequence Modeling with Cross-View Training](https://arxiv.org/abs/1809.08370) | [Official](https://github.com/tensorflow/models/tree/master/research/cvt_text) |


### PR DESCRIPTION
The results are not state-of-the-art, but they include a source code compared to the current SOTA model. Also they are SOTA for several nested NER datasets.