### PR TITLE
Add a result for English NER

### DIFF
--- a/english/named_entity_recognition.md
+++ b/english/named_entity_recognition.md
@@ -18,6 +18,7 @@ corpus tagged with four different entity types (PER, LOC, ORG, MISC). Models are
 | Model           | F1  |  Paper / Source | Code |
 | ------------- | :-----:| --- | --- |
 | CNN Large + fine-tune (Baevski et al., 2019) | 93.5 | [Cloze-driven Pretraining of Self-attention Networks](https://arxiv.org/pdf/1903.07785.pdf) | |
+| RNN-CRF+Flair | 93.47 | [Improved Differentiable Architecture Search for Language Modeling and Named Entity Recognition](https://www.aclweb.org/anthology/D19-1367/) | |
 | LSTM-CRF+ELMo+BERT+Flair | 93.38 | [Neural Architectures for Nested NER through Linearization](https://www.aclweb.org/anthology/P19-1527/) | [Official](https://github.com/ufal/acl2019_nested_ner) |
 | Flair embeddings (Akbik et al., 2018)♦ | 93.09 | [Contextual String Embeddings for Sequence Labeling](https://drive.google.com/file/d/17yVpFA7MmXaQFTe-HDpZuqw9fJlmzg56/view) | [Flair framework](https://github.com/zalandoresearch/flair)
 | BERT Large (Devlin et al., 2018) | 92.8 | [BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding](https://arxiv.org/abs/1810.04805) | |


### PR DESCRIPTION
This paper achieved a 93.47 F1 score on the CoNLL 2003 English NER task. We improved LSTM-CRF+Flair by a searched RNN cell. The code and pre-trained model will be released after another paper is published.