### PR TITLE
 Update results for the Google dataset in sentence compression

### DIFF
--- a/english/summarization.md
+++ b/english/summarization.md
@@ -200,6 +200,7 @@ Models are evaluated using the following metrics:
 
 | Model           | F1 | CR |Paper / Source | Code |
 | -------------   | :-----:| --- | --- | --- |
+| SLAHAN with syntactic information (Kamigaito et al. 2020) | 0.855 | 0.407 | [Syntactically Look-Ahead Attention Network for Sentence Compression](https://arxiv.org/abs/2002.01145) | https://github.com/kamigaito/SLAHAN |
 | BiRNN + LM Evaluator (Zhao et al. 2018) | 0.851 | 0.39 | [A Language Model based Evaluator for Sentence Compression](https://aclweb.org/anthology/P18-2028) | https://github.com/code4conference/code4sc |
 | LSTM (Filippova et al., 2015) | 0.82 | 0.38 | [Sentence Compression by Deletion with LSTMs](https://research.google.com/pubs/archive/43852.pdf) | |
 | BiLSTM (Wang et al., 2017) | 0.8 | 0.43 | [Can Syntax Help? Improving an LSTM-based Sentence Compression Model for New Domains](http://www.aclweb.org/anthology/P17-1127) |  |


### PR DESCRIPTION
I added the results of our paper [1] to the table for the Google dataset in the sentence compression section.
[1]: Kamigaito et al., 2020, "Syntactically Look-A-Head Attention Network for Sentence Compression", https://arxiv.org/abs/2002.01145