### PR TITLE
Include results from recent Xu et al paper

### DIFF
--- a/english/coreference_resolution.md
+++ b/english/coreference_resolution.md
@@ -23,6 +23,7 @@ CoNLL-2012 evaluation scripts. The main evaluation metric is the average F1 of t
 
 | Model           | Avg F1 |  Paper / Source | Code |
 | ------------- | :-----:| --- | --- |
+| Xu et al. (2020) | 80.2 | [Revealing the Myth of Higher-Order Inference in Coreference Resolution](https://arxiv.org/abs/2009.12013) |[Official](https://github.com/emorynlp/coref-hoi) |
 | Joshi et al. (2019)<sup>[1](#myfootnote1)</sup> | 79.6 | [SpanBERT: Improving Pre-training by Representing and Predicting Spans](https://arxiv.org/pdf/1907.10529) |[Official](https://github.com/facebookresearch/SpanBERT) |
 | Joshi et al. (2019)<sup>[2](#myfootnote2)</sup> | 76.9 | [BERT for Coreference Resolution: Baselines and Analysis](https://arxiv.org/abs/1908.09091) | [Official](https://github.com/mandarjoshi90/coref) |
 | Kantor and Globerson (2019) | 76.6 | [Coreference Resolution with Entity Equalization](https://www.aclweb.org/anthology/P19-1066/) | [Official](https://github.com/kkjawz/coref-ee) |


### PR DESCRIPTION
Their paper "Revealing the Myth of Higher-Order Inference in Coreference Resolution" is accepted at emnlp.