### PR TITLE
New end-to-end entity linking SotA from EACL 2021

### DIFF
--- a/english/entity_linking.md
+++ b/english/entity_linking.md
@@ -56,6 +56,7 @@ The [AIDA CoNLL-YAGO][AIDACoNLLYAGO] Dataset by [[Hoffart]](http://www.aclweb.or
    
 |  Paper / Source | Micro-F1-strong | Macro-F1-strong | Paper / Source | Code | 
 | ------------- | :-----:| :----: | :----: | --- |
+| Kannan Ravi et al. (2021) | NA | **83.1** | [CHOLAN: A Modular Approach for Neural Entity Linking on Wikipedia and Wikidata](https://arxiv.org/pdf/2101.09969.pdf) | [Official](https://github.com/ManojPrabhakar/CHOLAN) |
 | Kolitsas et al. (2018) | 82.6 | **82.4** | [End-to-End Neural Entity Linking](https://arxiv.org/pdf/1808.07699.pdf) | [Official](https://github.com/dalab/end2end_neural_el) |
 | van Hulst et al. (2020) | **83.3** | 81.3  | [REL: An Entity Linker Standing on the Shoulders of Giants](https://arxiv.org/abs/2006.01969) | [Official](https://github.com/informagi/REL) |
 | Piccinno et al. (2014) | 70.8 | 73.0 | [From TagME to WAT: a new entity annotator](https://dl.acm.org/citation.cfm?id=2634350) | |


### PR DESCRIPTION
Hi,
I have modified the end-to-end entity linking for CoNLL-AIDA dataset with a new paper to appear in EACL 2021.