### PR TITLE
Updated EL End-to-End Models

### DIFF
--- a/english/entity_linking.md
+++ b/english/entity_linking.md
@@ -56,9 +56,9 @@ The [AIDA CoNLL-YAGO][AIDACoNLLYAGO] Dataset by [[Hoffart]](http://www.aclweb.or
    
 |  Paper / Source | Micro-F1-strong | Macro-F1-strong | Paper / Source | Code | 
 | ------------- | :-----:| :----: | :----: | --- |
-| Kannan Ravi et al. (2021) | NA | **83.1** | [CHOLAN: A Modular Approach for Neural Entity Linking on Wikipedia and Wikidata](https://arxiv.org/pdf/2101.09969.pdf) | [Official](https://github.com/ManojPrabhakar/CHOLAN) |
-| Kolitsas et al. (2018) | 82.6 | **82.4** | [End-to-End Neural Entity Linking](https://arxiv.org/pdf/1808.07699.pdf) | [Official](https://github.com/dalab/end2end_neural_el) |
 | van Hulst et al. (2020) | **83.3** | 81.3  | [REL: An Entity Linker Standing on the Shoulders of Giants](https://arxiv.org/abs/2006.01969) | [Official](https://github.com/informagi/REL) |
+| Kolitsas et al. (2018) | 82.6 | **82.4** | [End-to-End Neural Entity Linking](https://arxiv.org/pdf/1808.07699.pdf) | [Official](https://github.com/dalab/end2end_neural_el) |
+| Kannan Ravi et al. (2021) | 83.1| - | [CHOLAN: A Modular Approach for Neural Entity Linking on Wikipedia and Wikidata](https://arxiv.org/pdf/2101.09969.pdf) | [Official](https://github.com/ManojPrabhakar/CHOLAN) |
 | Piccinno et al. (2014) | 70.8 | 73.0 | [From TagME to WAT: a new entity annotator](https://dl.acm.org/citation.cfm?id=2634350) | |
 | Hoffart et al. (2011) | 71.9 | 72.8 | [Robust Disambiguation of Named Entities in Text](http://www.aclweb.org/anthology/D11-1072) | |
 


### PR DESCRIPTION
- CHOLAN score is Micro-F1-strong not Macro-F1-strong
- Sorted the systems based on Micro-F1-strong, similar to Disambiguation-only models