### PR TITLE
Updated CCG progress

### DIFF
--- a/english/ccg.md
+++ b/english/ccg.md
@@ -53,9 +53,13 @@ section 00 for development, and section 23 as in-domain test set.
 
 To mitigate sparsity, CCG supertaggers have traditionally been trained only on categories that occur 10 times or more in the CCGBank training data, which amounts to the 425 most frequent categories. In more recent work, using this threshold is becoming less common. In any case, supertagging evaluation is always measured for all supertags occurring in the test set. Models are evaluated based on token accuracy.
 
+### Constructive supertagging
+
+A constructive tagger models the internal structure of supertags rather than treating each supertag type as opaque ([Kogkalidis et al., 2019](https://www.aclweb.org/anthology/W19-4314/)). Supertags are constructed from minimal pieces (which for CCG are slashes and atomic categories) and there is no frequency cutoff.
+
 ### CCGBank
 
-As for parsing, sections 2-21 are used for training, section 00 for development, and section 23 as in-domain test set.
+Like for parsing, sections 2-21 are used for training, section 00 for development, and section 23 as in-domain test set.
 
 | Model           | Accuracy |  Paper / Source |
 | ----------------- | :-----:| --- |

--- a/english/ccg.md
+++ b/english/ccg.md
@@ -12,8 +12,8 @@ Example:
 
 ## Parsing
 
-CCG parsing is evaluated in terms of labeled dependency F-score, which "take\[s\] into account the lexical category containing the dependency relation, the argument slot, the word associated with the lexical category, and the argument head word: All four must be correct to score a point." ([Clark & Curran, 2007](https://doi.org/10.1162/coli.2007.33.4.493))
-Besides the word forms, some popular parsers like the C&C parser, take POS tags as input. For fair comparison, systems should use automatically obtained POS as input, though some papers additionally report performance with oracle gold-standard POS features.
+CCG parsing is evaluated in terms of labeled dependency F-score, which "take\[s\] into account the lexical category containing the dependency relation, the argument slot, the word associated with the lexical category, and the argument head word: All four must be correct to score a point" ([Clark & Curran, 2007](https://doi.org/10.1162/coli.2007.33.4.493)).
+Besides the word forms, some popular parsers (like the C&C parser) take POS tags as input. For fair comparison, systems should use automatically obtained POS as input, though some papers additionally report performance with oracle gold-standard POS features.
 
 ### CCGBank
 

--- a/english/ccg.md
+++ b/english/ccg.md
@@ -12,13 +12,16 @@ Example:
 
 ## Parsing
 
+CCG parsing is evaluated in terms of labeled dependency F-score, which "take\[s\] into account the lexical category containing the dependency relation, the argument slot, the word associated with the lexical category, and the argument head word: All four must be correct to score a point." ([Clark & Curran, 2007](https://doi.org/10.1162/coli.2007.33.4.493))
+Besides the word forms, some popular parsers like the C&C parser, take POS tags as input. For fair comparison, systems should use automatically obtained POS as input, though some papers additionally report performance with oracle gold-standard POS features.
+
 ### CCGBank
 
 The CCGBank is a corpus of CCG derivations and dependency structures extracted from the Penn Treebank by
 [Hockenmaier and Steedman (2007)](http://www.aclweb.org/anthology/J07-3004). Sections 2-21 are used for training,
-section 00 for development, and section 23 as in-domain test set. Some work
+section 00 for development, and section 23 as in-domain test set.
 
-| Model           | Accuracy |  Paper / Source |
+| Model           | Labeled F-score |  Paper / Source |
 | ------------- | :-----:| --- |
 | Vaswani et al. (2016) | 88.32 | [Supertagging with LSTMs](https://aclweb.org/anthology/N/N16/N16-1027.pdf) |
 | Lewis et al. (2016) | 88.1 | [LSTM CCG Parsing](https://aclweb.org/anthology/N/N16/N16-1026.pdf) |
@@ -45,9 +48,11 @@ section 00 for development, and section 23 as in-domain test set. Some work
 
 ## Supertagging
 
+To mitigate sparsity, CCG supertaggers have traditionally been trained only on categories that occur 10 times or more in the CCGBank training data, which amounts to the 425 most frequent categories. In more recent work, using this threshold is becoming less common. In any case, supertagging evaluation is always measured for all supertags occurring in the test set. Models are evaluated based on token accuracy.
+
 ### CCGBank
 
-For Supertagging evaluation on CCGBank, performance is only calculated over the 425 most frequent labels. Models are evaluated based on accuracy.
+As for parsing, sections 2-21 are used for training, section 00 for development, and section 23 as in-domain test set.
 
 | Model           | Accuracy |  Paper / Source |
 | ------------- | :-----:| --- |

--- a/english/ccg.md
+++ b/english/ccg.md
@@ -23,6 +23,9 @@ section 00 for development, and section 23 as in-domain test set.
 
 | Model           | Labeled F-score |  Paper / Source |
 | ------------- | :-----:| --- |
+| Prange et al. (2021), non-constructive, no tag threshold | 90.91 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| Bhargava and Penn (2020), constructive | 90.9 | [Supertagging with CCG primitives](https://www.aclweb.org/anthology/2020.repl4nlp-1.23/) |
+| Prange et al. (2021), constructive | 90.79 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
 | Vaswani et al. (2016) | 88.32 | [Supertagging with LSTMs](https://aclweb.org/anthology/N/N16/N16-1027.pdf) |
 | Lewis et al. (2016) | 88.1 | [LSTM CCG Parsing](https://aclweb.org/anthology/N/N16/N16-1026.pdf) |
 | Xu et al. (2015) | 87.04 | [CCG Supertagging with a Recurrent Neural Network](http://www.aclweb.org/anthology/P15-2041) |
@@ -56,12 +59,31 @@ As for parsing, sections 2-21 are used for training, section 00 for development,
 
 | Model           | Accuracy |  Paper / Source |
 | ------------- | :-----:| --- |
-| Clark et al. (2018) | 96.1 | [Semi-Supervised Sequence Modeling with Cross-View Training](https://arxiv.org/abs/1809.08370) |
+| Prange et al. (2021), non-constructive, no tag threshold | 96.22 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| Prange et al. (2021), constructive | 96.09 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| Clark et al. (2018) | 96.05 | [Semi-Supervised Sequence Modeling with Cross-View Training](https://arxiv.org/abs/1809.08370) |
+| Bhargava and Penn (2020), constructive | 96.00 | [Supertagging with CCG primitives](https://www.aclweb.org/anthology/2020.repl4nlp-1.23/) |
 | Lewis et al. (2016) | 94.7 | [LSTM CCG Parsing](https://aclweb.org/anthology/N/N16/N16-1026.pdf) |
 | Vaswani et al. (2016) | 94.24 | [Supertagging with LSTMs](https://aclweb.org/anthology/N/N16/N16-1027.pdf) |
 | Low supervision (Søgaard and Goldberg, 2016) | 93.26 | [Deep multi-task learning with low level tasks supervised at lower layers](http://anthology.aclweb.org/P16-2038) |
 | Xu et al. (2015) | 93.00 | [CCG Supertagging with a Recurrent Neural Network](http://www.aclweb.org/anthology/P15-2041) |
 | Clark and Curran (2004) | 92.00 | [The Importance of Supertagging for Wide-Coverage CCG Parsing](https://aclweb.org/anthology/papers/C/C04/C04-1041/) (result from Lewis et al. (2016)) |
+
+#### Rare and unseen supertags
+
+| Model           | Acc on tags seen 1-9 times | Acc on unseen tags |  Paper / Source |
+| ------------- | :-----:| --- |
+| Prange et al. (2021), constructive | 37.40 | 3.03 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| Prange et al. (2021), non-constructive, no tag threshold | 23.17 | 0.00 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| Bhargava and Penn (2020), constructive | - | 5.00 | [Supertagging with CCG primitives](https://www.aclweb.org/anthology/2020.repl4nlp-1.23/)
+
+### Wikipedia
+
+| Model           | Accuracy |  Paper / Source |
+| ------------- | :-----:| --- |
+| Prange et al. (2021), non-constructive | 92.54 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| Prange et al. (2021), constructive | 92.46 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| Xu et al. (2015) | 90.00 | [CCG Supertagging with a Recurrent Neural Network](http://www.aclweb.org/anthology/P15-2041) |
 
 ## Conversion to PTB
 

--- a/english/ccg.md
+++ b/english/ccg.md
@@ -23,7 +23,7 @@ section 00 for development, and section 23 as in-domain test set.
 
 | Model           | Labeled F-score |  Paper / Source |
 | ------------- | :-----:| --- |
-| Prange et al. (2021), non-constructive, no tag threshold | 90.91 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| Prange et al. (2021), non-constructive | 90.91 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
 | Bhargava and Penn (2020), constructive | 90.9 | [Supertagging with CCG primitives](https://www.aclweb.org/anthology/2020.repl4nlp-1.23/) |
 | Prange et al. (2021), constructive | 90.79 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
 | Vaswani et al. (2016) | 88.32 | [Supertagging with LSTMs](https://aclweb.org/anthology/N/N16/N16-1027.pdf) |
@@ -58,8 +58,8 @@ To mitigate sparsity, CCG supertaggers have traditionally been trained only on c
 As for parsing, sections 2-21 are used for training, section 00 for development, and section 23 as in-domain test set.
 
 | Model           | Accuracy |  Paper / Source |
-| ------------- | :-----:| --- |
-| Prange et al. (2021), non-constructive, no tag threshold | 96.22 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| ----------------- | :-----:| --- |
+| Prange et al. (2021), non-constructive | 96.22 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
 | Prange et al. (2021), constructive | 96.09 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
 | Clark et al. (2018) | 96.05 | [Semi-Supervised Sequence Modeling with Cross-View Training](https://arxiv.org/abs/1809.08370) |
 | Bhargava and Penn (2020), constructive | 96.00 | [Supertagging with CCG primitives](https://www.aclweb.org/anthology/2020.repl4nlp-1.23/) |
@@ -72,15 +72,15 @@ As for parsing, sections 2-21 are used for training, section 00 for development,
 #### Rare and unseen supertags
 
 | Model           | Acc on tags seen 1-9 times | Acc on unseen tags |  Paper / Source |
-| ------------- | :-----: | ----- | --- |
-| Prange et al. (2021), constructive | 37.40 | 3.03 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| ------------- | :-----: | :-----: | --- |
 | Bhargava and Penn (2020), constructive | - | 5.00 | [Supertagging with CCG primitives](https://www.aclweb.org/anthology/2020.repl4nlp-1.23/) |
-| Prange et al. (2021), non-constructive, no tag threshold | 23.17 | 0.00 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| Prange et al. (2021), constructive | 37.40 | 3.03 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| Prange et al. (2021), non-constructive | 23.17 | 0.00 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
 
 ### Wikipedia
 
 | Model           | Accuracy |  Paper / Source |
-| ------------- | :-----:| --- |
+| ------------- | :-----: | --- |
 | Prange et al. (2021), non-constructive | 92.54 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
 | Prange et al. (2021), constructive | 92.46 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
 | Xu et al. (2015) | 90.00 | [CCG Supertagging with a Recurrent Neural Network](http://www.aclweb.org/anthology/P15-2041) |

--- a/english/ccg.md
+++ b/english/ccg.md
@@ -72,10 +72,10 @@ As for parsing, sections 2-21 are used for training, section 00 for development,
 #### Rare and unseen supertags
 
 | Model           | Acc on tags seen 1-9 times | Acc on unseen tags |  Paper / Source |
-| ------------- | :-----:| --- |
+| ------------- | :-----: | ----- | --- |
 | Prange et al. (2021), constructive | 37.40 | 3.03 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
+| Bhargava and Penn (2020), constructive | - | 5.00 | [Supertagging with CCG primitives](https://www.aclweb.org/anthology/2020.repl4nlp-1.23/) |
 | Prange et al. (2021), non-constructive, no tag threshold | 23.17 | 0.00 | [Supertagging the Long Tail with Tree-Structured Decoding of Complex Categories](https://doi.org/10.1162/tacl_a_00364) |
-| Bhargava and Penn (2020), constructive | - | 5.00 | [Supertagging with CCG primitives](https://www.aclweb.org/anthology/2020.repl4nlp-1.23/)
 
 ### Wikipedia
 


### PR DESCRIPTION
- Clarified evaluation procedures and metrics for parsing and supertagging
- Explained constructive supertagging
- Added recent constructive supertagging results from Bhargava & Penn (2020) and Prange et al. (2021)
- Added new results tables for supertagging on Wikipedia domain and retrieving rare supertags

I'm not sure how appropriate it is to report 2 different results from our own paper (constructive and non-constructive), so let me know if I should remove one of them, but I think it is more transparent this way, especially as more people are starting to work on constructive tagging.