### PR TITLE
fix: article link for Knowledge-based WSD

### DIFF
--- a/english/word_sense_disambiguation.md
+++ b/english/word_sense_disambiguation.md
@@ -56,8 +56,8 @@ The main evaluation measure is F1-score.
 | ------------- | :-----: | :-----: | :-----: | :-----: | :-----: | :-----: | --- |
 |WN 1st sense baseline | 65.2 | 66.8 | 66.2 | 55.2 | 63.0 | 67.8 | [[1]](http://aclweb.org/anthology/E/E17/E17-1010.pdf) |
 |Babelfy | 65.5 | 67.0 | 63.5 | 51.6 | 66.4 | 70.3 | [[8]](http://aclweb.org/anthology/Q14-1019) |
-|UKB<sub>ppr_w2w-nf</sub> | 57.5 | 64.2 | 54.8 | 40.0 | 64.5 | 64.5 | [[9]](https://www.mitpressjournals.org/doi/full/10.1162/COLI_a_00164) [[12]](http://aclweb.org/anthology/W18-2505) |
-|UKB<sub>ppr_w2w</sub> | 67.3 | 68.8 | 66.1 | 53.0 | **68.8** | 70.3 | [[9]](https://www.mitpressjournals.org/doi/full/10.1162/COLI_a_00164) [[12]](http://aclweb.org/anthology/W18-2505) |
+|UKB<sub>ppr_w2w-nf</sub> | 57.5 | 64.2 | 54.8 | 40.0 | 64.5 | 64.5 | [[9]](https://direct.mit.edu/coli/article/40/1/57/1454/Random-Walks-for-Knowledge-Based-Word-Sense) [[12]](http://aclweb.org/anthology/W18-2505) |
+|UKB<sub>ppr_w2w</sub> | 67.3 | 68.8 | 66.1 | 53.0 | **68.8** | 70.3 | [[9]](https://direct.mit.edu/coli/article/40/1/57/1454/Random-Walks-for-Knowledge-Based-Word-Sense) [[12]](http://aclweb.org/anthology/W18-2505) |
 |WSD-TM | 66.9 | 69.0 | **66.9** | 55.6 | 65.3 | 69.6 | [[10]](https://arxiv.org/pdf/1801.01900.pdf) |
 |KEF | **68.0** | **69.6** | 66.1 | **56.9** | 68.4 | **72.3** | [[16]](https://doi.org/10.1016/j.knosys.2019.105030) [[code]](https://github.com/lwmlyy/Knowledge-based-WSD)|
 
@@ -79,7 +79,7 @@ Note: 'All' is the concatenation of all datasets, as described in [10] and [12].
 
 [8] [Entity Linking meets Word Sense Disambiguation: A Unified Approach](http://aclweb.org/anthology/Q14-1019)
 
-[9] [Random walks for knowledge-based word sense disambiguation](https://www.mitpressjournals.org/doi/full/10.1162/COLI_a_00164)
+[9] [Random walks for knowledge-based word sense disambiguation](https://direct.mit.edu/coli/article/40/1/57/1454/Random-Walks-for-Knowledge-Based-Word-Sense)
 
 [10] [Knowledge-based Word Sense Disambiguation using Topic Models](https://arxiv.org/pdf/1801.01900.pdf)
 


### PR DESCRIPTION
Fixes a link that was broken. I couldn't find or access the original link at [1]. Searching around, the suitable replacement seemed to be [2]. Fix by replacing the link. 

1. https://www.mitpressjournals.org/doi/full/10.1162/COLI_a_00164
2. https://direct.mit.edu/coli/article/40/1/57/1454/Random-Walks-for-Knowledge-Based-Word-Sense